### PR TITLE
Dereference symlinks at the end of the build

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,7 +1,9 @@
 var path = require('path');
 var broccoli = require('broccoli');
 var rimraf = require('rimraf');
-var helpers = require('broccoli-kitchen-sink-helpers');
+var mkdirp = require('mkdirp');
+var path = require('path');
+var copyDereferenceSync = require('copy-dereference').sync;
 var Watcher = require('broccoli/lib/watcher');
 
 var plugin = {
@@ -25,7 +27,8 @@ var plugin = {
     return builder.build()
       .then(function(output) {
         rimraf.sync(dest);
-        helpers.copyRecursivelySync(output.directory, dest);
+        mkdirp.sync(path.join(dest, '..'));
+        copyDereferenceSync(output.directory, dest);
         return output;
       });
   },
@@ -39,7 +42,8 @@ var plugin = {
     return watcher.on('change', function(results) {
       console.log('\n\nChange detected');
       rimraf.sync(dest);
-      helpers.copyRecursivelySync(results.directory, dest);
+      mkdirp.sync(path.join(dest, '..'));
+      copyDereferenceSync(results.directory, dest);
       console.log('Build successful\n');
       watcher.emit("livereload");
     });

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "url": "https://github.com/quandl/grunt-broccoli.git"
   },
   "dependencies": {
-    "grunt": "~0.4.2",
     "broccoli": "~0.12.3",
-    "broccoli-kitchen-sink-helpers": "0.2.4",
+    "copy-dereference": "^1.0.0",
+    "grunt": "~0.4.2",
+    "mkdirp": "^0.5.0",
     "rimraf": "~2.2.6",
     "tiny-lr": "^0.1.4"
   },


### PR DESCRIPTION
Resolves an issue I've mentioned [here](https://github.com/quandl/grunt-broccoli/issues/23#issuecomment-73509784).
Beginning with Broccoli 0.13, the build process uses symlinks where possible. In tools using Broccoli programmatically, this results in the destination directory containing symlinks to files and directories in `tmp`.

This is exactly what broccoli-cli [recommends to do](https://github.com/broccolijs/broccoli/blob/master/docs/symlink-change.md#auto-dereference-symlinks-after-build) ([see also their code](https://github.com/broccolijs/broccoli/blob/48e9b5f450f4dd59e424713c7a9c901b15bc6746/lib/cli.js#L33)).

Note on using `mkdirp` and `path`: the parent directory of the destination directory has to exist before `copyDereferenceSync` can do its job. The destination directory itself should not exist.