### PR TITLE
Inform Grunt when build fails

### DIFF
--- a/tasks/broccoli.js
+++ b/tasks/broccoli.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
         done();
       }, function(err) {
         grunt.log.error(err);
+        done(false);
       });
     } else if(command === 'watch') {
       if (!dest) {


### PR DESCRIPTION
Currently, when the Broccoli build fails, it doesn't inform Grunt about the failure. As a result, grunt never exits, which is a big issue when running it on CI.
This PR adds a missing `done(false)` call.