### PR TITLE
update broccoli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-broccoli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Broccoli build and serve tasks for Grunt task runner",
   "main": "Gruntfile.js",
   "tags": [
@@ -17,7 +17,7 @@
     "url": "https://github.com/quandl/grunt-broccoli.git"
   },
   "dependencies": {
-    "broccoli": "~0.12.3",
+    "broccoli": "~0.16.3",
     "copy-dereference": "^1.0.0",
     "grunt": "~0.4.2",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
Updates broccoli version to fix some issues with newer broccoli plugins, e.g. broccoli-babel-transpiler. fixes quandl/grunt-broccoli#30