### PR TITLE
Bump broccoli version to 0.15.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-broccoli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Broccoli build and serve tasks for Grunt task runner",
   "main": "Gruntfile.js",
   "tags": [
@@ -17,7 +17,7 @@
     "url": "https://github.com/quandl/grunt-broccoli.git"
   },
   "dependencies": {
-    "broccoli": "~0.12.3",
+    "broccoli": "~0.15.3",
     "copy-dereference": "^1.0.0",
     "grunt": "~0.4.2",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
When using broccoli 0.12.3 returning trees from broccoli-babel-transpiler fails with:
```
Error: Invalid tree found. You must supply a path or an object with a `read` function.
```
Bumping version fixes this issue. Tests still pass.